### PR TITLE
Add deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Neuro-Transmitter Questionnaire
+
+This repository contains a static web application for the Neuro-Transmitter Questionnaire.
+
+## Local Development
+
+You can serve the application locally using Python's built-in HTTP server:
+
+```bash
+cd neuro-transmitter-final
+python3 -m http.server 8000
+```
+
+Then open your browser and navigate to `http://localhost:8000`.
+
+## Deployment
+
+Since the app is static (HTML, CSS, and JavaScript), it can be hosted on any static web server or service such as GitHub Pages, Netlify, or Vercel. To deploy with GitHub Pages:
+
+1. Copy the contents of `neuro-transmitter-final` to the root of your repository or a `docs` folder.
+2. Commit and push the changes.
+3. Enable GitHub Pages in the repository settings, pointing to the branch/folder that contains the files.
+


### PR DESCRIPTION
## Summary
- add README with simple instructions to serve the app locally and deploy as a static site

## Testing
- `python3 -m http.server 8000`